### PR TITLE
Change determination of absolute path

### DIFF
--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -345,7 +345,7 @@ class Folder
      */
     public static function isRegisteredStreamWrapper($path)
     {
-        return preg_match('/^[A-Z]+(?=:\/\/)/i', $path, $matches) &&
+        return preg_match('/^[^:\/\/]+?(?=:\/\/)/i', $path, $matches) &&
             in_array($matches[0], stream_get_wrappers());
     }
 

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1391,4 +1391,23 @@ class FolderTest extends TestCase
 
         $this->assertSame(['a.txt', 'b.txt', 'c.txt'], $results);
     }
+    
+    /**
+     * testIsRegisteredStreamWrapper
+     *
+     * @return void
+     */
+    public function testIsRegisteredStreamWrapper()
+    {
+        foreach (stream_get_wrappers() as $wrapper) {
+            $this->assertTrue(Folder::isRegisteredStreamWrapper($wrapper . "://path/to/file"));
+            $this->assertFalse(Folder::isRegisteredStreamWrapper("bad." . $wrapper . "://path/to/file"));
+        }
+
+        $wrapper = 'unit.test1-';
+        $this->assertFalse(Folder::isRegisteredStreamWrapper($wrapper . "://path/to/file"));
+        stream_wrapper_register($wrapper, self::class);
+        $this->assertTrue(Folder::isRegisteredStreamWrapper($wrapper . "://path/to/file"));
+        stream_wrapper_unregister($wrapper);
+    }
 }

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -1391,7 +1391,7 @@ class FolderTest extends TestCase
 
         $this->assertSame(['a.txt', 'b.txt', 'c.txt'], $results);
     }
-    
+
     /**
      * testIsRegisteredStreamWrapper
      *


### PR DESCRIPTION
Determine all strings before ': //' and the result of stream_get_wrappers().

`var_export(stream_get_wrappers());`

```
array (
  0 => 'https',
  1 => 'ftps',
  2 => 'compress.zlib',
  3 => 'php',
  4 => 'file',
  5 => 'glob',
  6 => 'data',
  7 => 'http',
  8 => 'ftp',
  9 => 'compress.bzip2',
  10 => 'phar',
  11 => 's3',
)
```
`compress.zlib`, `compress.bzip2` and `s3` do not match.
